### PR TITLE
Updated the stack.yaml to use the latest resolver version: lts-20.16

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,2 @@
-resolver: lts-16.6
+resolver: lts-20.16
 packages:


### PR DESCRIPTION
This PR fixes the issues: #1 and #2. 

Tested on both Windows and MacOS.